### PR TITLE
Adding sample site + nuxt config for translation

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -7,4 +7,34 @@ export default {
     host: config.mca.host,
     port: config.mca.port,
   },
+  modules: [
+    [
+      'nuxt-i18n',
+      {
+        locales: [
+          {
+            code: 'en', 
+            name: 'English',
+            file: 'en.json'
+          },
+          {
+            code: 'de', 
+            name: 'German',
+            file: 'de.json'
+          },
+          {
+            code: 'cn', 
+            name: 'Chinese',
+            file: 'cn.json'
+          },
+        ],
+        defaultLocale: 'en',
+        lazy: true,
+        langDir: '../CorsaceAssets/lang/',
+        vueI18n: {
+          fallbackLocale: 'en',
+        }
+      }
+    ]
+  ],
 }

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,5 +1,17 @@
 import { Config } from "../config"
+import * as fs from "fs"
+
 const config = new Config;
+const locales = []
+
+fs.readdirSync("../CorsaceAssets/lang").forEach(file => {
+  if (file !== "example.json")
+    locales.push({
+      code: file.split(".")[0],
+      file,
+    })
+})
+
 export default {
   serverMiddleware: ['~/api'],
   buildModules: ['@nuxt/typescript-build'],
@@ -11,23 +23,7 @@ export default {
     [
       'nuxt-i18n',
       {
-        locales: [
-          {
-            code: 'en', 
-            name: 'English',
-            file: 'en.json'
-          },
-          {
-            code: 'de', 
-            name: 'German',
-            file: 'de.json'
-          },
-          {
-            code: 'cn', 
-            name: 'Chinese',
-            file: 'cn.json'
-          },
-        ],
+        locales,
         defaultLocale: 'en',
         lazy: true,
         langDir: '../CorsaceAssets/lang/',

--- a/pages/jsonFiller.vue
+++ b/pages/jsonFiller.vue
@@ -5,7 +5,7 @@
 		:key="locale.code"
 		:to="switchLocalePath(locale.code)"
 		>
-		<p>{{ locale.name }}</p>
+		<p>{{ locale.code }}</p>
 	</nuxt-link>
 
 

--- a/pages/jsonFiller.vue
+++ b/pages/jsonFiller.vue
@@ -1,0 +1,26 @@
+<template>
+  <div>
+	<nuxt-link
+		v-for="locale in availableLocales"
+		:key="locale.code"
+		:to="switchLocalePath(locale.code)"
+		>
+		<p>{{ locale.name }}</p>
+	</nuxt-link>
+
+
+	<div v-html="$t('ayim.index.home')" />
+  </div>
+</template>
+
+<script>
+
+export default {
+	computed: {
+		availableLocales () {
+			return this.$i18n.locales.filter(i => i.code !== this.$i18n.locale)
+		}
+	}
+}
+
+</script>


### PR DESCRIPTION
Languages and their respective translation files go into the module configuration in nuxt.config.ts

The site (jsonFiller) displays all languages that have translations on top. By clicking you switch to that language. In the template itself the translation is available via the $t('key') variable.